### PR TITLE
 Only configure keymaps when not nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ luac.out
 *.hex
 
 .luarc.json
+
+doc/

--- a/lua/date-time-inserter/init.lua
+++ b/lua/date-time-inserter/init.lua
@@ -156,6 +156,12 @@ local function set_keymap(key, command)
     keymap('n', key, command, opts)
 end
 
+-- Check if a setting is nil or empty.
+-- @param setting: The setting to check.
+local function setting_is_empty(setting)
+    return setting == nil or setting == ''
+end
+
 -- Set the settings, if any where passed.
 -- If none are passed, the default settings will be used.
 -- @param opts: Plugin settings.
@@ -165,10 +171,18 @@ M.setup = function(opts)
             settings[k] = v
         end
     end
-    -- Set the keymaps for the plugin.
-    set_keymap(settings.insert_date_map, M.insert_date)
-    set_keymap(settings.insert_time_map, M.insert_time)
-    set_keymap(settings.insert_date_time_map, M.insert_date_time)
+
+    if not setting_is_empty(opts.insert_date_time_map) then
+        set_keymap(opts.insert_date_time_map, M.insert_date_time)
+    end
+
+    if not setting_is_empty(opts.insert_time_map) then
+        set_keymap(opts.insert_time_map, M.insert_time)
+    end
+
+    if not setting_is_empty(opts.insert_date_map) then
+        set_keymap(opts.insert_date_map, M.insert_date)
+    end
 end
 
 -- Insert the current date into the current buffer.


### PR DESCRIPTION
Fixes #1 

## Proposed Changes
This implements a check (`setting_is_empty`) to determine whether the user has configured keymaps in his config. If the keymap is set to `nil` or an empty string, the corresponding mappings for inserting date, time, and date-time will not be configured. 

This enhancement ensures that the plugin remains flexible in customization, avoiding errors when keymaps are not explicitly set.